### PR TITLE
Build the actual list of ranks to receive work from in dcp2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ LaFon, Jharrod <jlafon@lanl.gov>
 Li, Xi <lixi@ddn.com>
 Moody, Adam <moody20@llnl.gov>
 Wang, Feiyi <fwang2@ornl.gov>
+Wellington, Andrew <andrew.wellington@anu.edu.au>


### PR DESCRIPTION
The list of ranks sending us work is not necessarily sequential, treating it as such leads to hung processes awaiting messages that will never be sent. This is especially prevalent as the number of ranks increases.